### PR TITLE
fix: docker-compose fails to run app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 # We'll use this image because it's lightweight and has almost everything we need
 FROM mhart/alpine-node:6.14.3
 
-# Install python
-RUN apt-get update && apt-get install -y build-essential && apt-get install -y python && npm install
+# Install build-essential equivalent and python
+RUN apk update && apk add dpkg-dev && apk add g++ && apk add gcc && apk add libc-dev && apk add make && apk add python
 
 # Add everything from our local project directory to our container in the `/skrypt` directory
 RUN mkdir /skrypt
@@ -14,14 +14,11 @@ RUN mkdir /skrypt
 # Make the `/skrypt` directory inside the container the work directory
 WORKDIR /skrypt
 
-# Copy `package.json` from host project directory root into `/skrypt` inside the app container
-COPY package.json /skrypt
-
-# Run `npm install` to install all of the dependencies in `package.json`
-RUN npm rebuild bcrypt --build-from-source=bcrypt
-
 # Now copy everything from host project directory root into `/skrypt` inside the app container
 COPY . /skrypt
+
+# Run `npm install` to install all of the dependencies in `package.json`
+RUN npm install -g nodemon && npm install && npm rebuild bcrypt --build-from-source=bcrypt 
 
 # Expose port `3000` so we can connect through that port
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,16 +49,15 @@ services:
       - NODE_ENV=${NODE_ENV}
 
     # Mount root of host project directory to `/skrypt` directory in container
-    volumes:
-      - .:/skrypt
+    # NOTE: uncommenting the volumes config will force the container to use the
+    #       node_modules folder on the host machine. this can cause problems if
+    #       host is using a different architecture than the container
+    # volumes:
+    #   - .:/skrypt
 
     # Use port 3000 on both host and container when connecting
     ports:
       - "3000:3000"
-
-    # Create a link between mongo and app containers
-    links:
-      - skrypt_db
 
     # Start mongo container before app container (does not wait for mongo to be up and running before starting app container)
     depends_on:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "set DEBUG=* & nodemon index.js"
+    "start": "set DEBUG=* && nodemon index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- package installation requires apk for alpine linux
- install nodemon globally in container for npm start script to work
- remove "links" from docker-compose.yml, this is not required
  (see https://docs.docker.com/compose/networking/#links)
- do not mount host root dir to /skrypt, causes issues with node_modules
  (see https://github.com/DanWahlin/CodeWithDanDockerServices/issues/1#issuecomment-275918075)

fixes #21